### PR TITLE
Update gemspec for Bundler's github install

### DIFF
--- a/utilityapi.gemspec
+++ b/utilityapi.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.version       = UtilityApi::VERSION
   spec.author        = 'AUTHOR'
   spec.email         = 'EMAIL'
-  spec.homepage      = 'HOMEPAGE'
+  spec.homepage      = 'https://github.com/utilityapi/ruby-sdk'
 
   spec.summary       = 'Ruby SDK for the Utility API websity API: http://utilityapi.com/api.'
   spec.description   = <<-DESCRIPTION


### PR DESCRIPTION
In my current project, we're installing `utilityapi` in our `Gemfile`, like this:

```ruby
gem 'utilityapi', github: 'utilityapi/ruby-sdk'
```

After running `bundle install` and then running the tests, I was getting errors saying that the gem wasn't loaded correctly:
```
      NameError:
        uninitialized constant UtilityApi::Models
 ```

I found the problem after running `bundle open utilityapi`:

```
 wexus (master) ✗ bundle open utilityapi
The gemspec at /Users/grayson/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/ruby-sdk-7b249f98256d/utilityapi.gemspec is not valid. The validation error was '"HOMEPAGE" is not a URI'
Could not find utilityapi-0.1.0 in any of the sources
```

After I updated the URL on my local download of the gem, it worked for me.